### PR TITLE
Update options.xul

### DIFF
--- a/source/chrome/content/options.xul
+++ b/source/chrome/content/options.xul
@@ -70,7 +70,7 @@
 			</hbox>
 			<hbox>
 				<label accesskey="&bHistoryItemLimitNumr.accesskey;" control="bHistoryItemLimitNumr">&bHistoryItemLimitNumr.label;</label>
-				<textbox id="bHistoryItemLimitNumr" type="number" min="1" max="5000" preference="bHistoryItemLimitPref" width="100" />
+				<textbox id="bHistoryItemLimitNumr" type="number" min="1" max="100000000" preference="bHistoryItemLimitPref" width="200" />
 			</hbox>
 		</groupbox>
 		


### PR DESCRIPTION
Hi,
I've been running your add-on with a larger history limit.  With the new firefox signing policy, I can no longer update in place.  Could you add this change which creates a ridiculously large limit (1 year has created ~500,000 entries for me), and re-release the add-on, so the new version with the increased limit is the signed version?

I was just going to send you a patch for such a small change, but that seems impossible.

Thanks.
